### PR TITLE
fixing settings for gh-pages deployment

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ REACT_APP_IMAGE_URL="https://perseids-publications.github.io/gorman-trees/persei
 REACT_APP_SITE_NAME="The Perseids Project"
 REACT_APP_TITLE="Gorman Trees"
 REACT_APP_DESCRIPTION="Greek prose trees by Vanessa Gorman"
-REACT_APP_URL="https://perseids-publications.github.io/gorman-trees/"
+REACT_APP_URL="https://rgorman.github.io/rg-trees/"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "gorman-trees",
+  "name": "rg-trees",
   "version": "1.0.1",
   "treebank-template": {
     "version": "3.0.2"
   },
   "private": true,
-  "homepage": "https://perseids-publications.github.io/gorman-trees/",
+  "homepage": "https://rgorman.github.io/rg-trees/",
   "dependencies": {
     "@primer/octicons-react": "^9.6.0",
     "alpheios-messaging": "https://github.com/alpheios-project/alpheios-messaging",


### PR DESCRIPTION
Bob, 

I think these are all of the changes needed to get it minimally working under github pages

After you merge this PR, pull to your local system and run the following from the rg-trees directory at the command line (assuming you have installed yarn):

yarn install
yarn deploy

This should deploy the built code to the gh-pages branch of the repository and then you should see it at https://rgorman.github.io/rg-trees

At that point, you would use the following settings in your html page for linking to Alpheios

data-alpheios_tb_url="https://rgorman.github.io/rg-trees/embed/DOC/SENTENCE"

and for a document e.g.

data-alpheios_tb_doc="aeschines-1-1-50-bu1"


@zfletch I think maybe we need to provide step by step instructions for setting up a repo. I am happy to help draft that if you want.